### PR TITLE
Add initial Next.js todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # codex-tester
+
+This is a minimal Next.js project using TypeScript. It includes a simple Todo list page.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to see the Todo list page.

--- a/components/TodoList.tsx
+++ b/components/TodoList.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+
+export default function TodoList() {
+  const [task, setTask] = useState('');
+  const [todos, setTodos] = useState<string[]>([]);
+
+  const addTodo = () => {
+    if (task.trim() === '') return;
+    setTodos([...todos, task.trim()]);
+    setTask('');
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      addTodo();
+    }
+  };
+
+  return (
+    <div>
+      <h1>Todo List</h1>
+      <input
+        type="text"
+        value={task}
+        onChange={(e) => setTask(e.target.value)}
+        onKeyPress={handleKeyPress}
+        placeholder="Add a new task"
+      />
+      <button onClick={addTodo}>Add</button>
+      <ul>
+        {todos.map((todo, index) => (
+          <li key={index}>{todo}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "codex-tester",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest",
+    "@types/react": "latest",
+    "@types/node": "latest"
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+import TodoList from '../components/TodoList';
+
+export default function Home() {
+  return (
+    <div>
+      <Head>
+        <title>Todo App</title>
+        <meta name="description" content="Simple Todo app with Next.js" />
+      </Head>
+      <main>
+        <TodoList />
+      </main>
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up a basic Next.js project in TypeScript
- add a Todo list component and page
- document local development steps

## Testing
- `npm run build` *(fails: next not found)*